### PR TITLE
Make arduino-homebridge-mqtt compatible with the Arduino IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Arduino library for connecting to Homebridge.
 
 ### Installation Guide
 * [PlatformIO](http://platformio.org/lib)
+* [Arduino IDE](https://www.arduino.cc/en/Guide/Libraries#toc4)

--- a/examples/HumiditySensorExample/HumiditySensorExample.ino
+++ b/examples/HumiditySensorExample/HumiditySensorExample.ino
@@ -1,0 +1,3 @@
+// This file intentionally left empty
+// This file is used to provide compatibility with the Arduino IDE
+// See other tab for the code

--- a/examples/LightSensorExample/LightSensorExample.ino
+++ b/examples/LightSensorExample/LightSensorExample.ino
@@ -1,0 +1,3 @@
+// This file intentionally left empty
+// This file is used to provide compatibility with the Arduino IDE
+// See other tab for the code

--- a/examples/SprinklerExample/Sprinkler.ino
+++ b/examples/SprinklerExample/Sprinkler.ino
@@ -1,0 +1,3 @@
+// This file intentionally left empty
+// This file is used to provide compatibility with the Arduino IDE
+// See other tab for the code

--- a/examples/SwitchExample/SwitchExample.ino
+++ b/examples/SwitchExample/SwitchExample.ino
@@ -1,0 +1,3 @@
+// This file intentionally left empty
+// This file is used to provide compatibility with the Arduino IDE
+// See other tab for the code

--- a/examples/ThermostatExample/ThermostatExample.ino
+++ b/examples/ThermostatExample/ThermostatExample.ino
@@ -1,0 +1,3 @@
+// This file intentionally left empty
+// This file is used to provide compatibility with the Arduino IDE
+// See other tab for the code

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=ArduinoHomebridgeMqtt
+version=0.1.8
+author=Warit Santaputra <waritsan@gmail.com>
+maintainer=Warit Santaputra <waritsan@gmail.com>
+sentence=Arduino library for connecting to Homebridge
+paragraph=
+category=Communication
+url=https://github.com/waritsan/arduino-homebridge-mqtt
+architectures=esp8266


### PR DESCRIPTION
- Add library.properties metadata file. This file is required for the Arduino IDE to recognize libraries in the 1.5 format (source files under the src subfolder).
- Add dummy .ino files to the examples. The Arduino IDE requires a .ino file in the folder to recognize it as a valid sketch. These dummy files are left empty other than an explanatory comment.
- Add Arduino IDE library installation instructions link to README.md.