### PR TITLE
Fix MQTT connect

### DIFF
--- a/src/ArduinoHomebridgeMqtt.cpp
+++ b/src/ArduinoHomebridgeMqtt.cpp
@@ -66,8 +66,8 @@ void ArduinoHomebridgeMqtt::connect(IPAddress server) {
 
 void ArduinoHomebridgeMqtt::connect() {
   Serial.print("Connecting to MQTT host...");
-  mqttClient.connect();
   while (!mqttClient.connected()) {
+    mqttClient.connect();
     Serial.print(".");
     delay(1000);
   }


### PR DESCRIPTION
In the original order, `mqttClient.connect();` will only be called once if the MQTT server is unavailable. The program will be stuck in while loop even if the MQTT server available again.