### PR TITLE
Support optional and custom characteristics

### DIFF
--- a/src/ArduinoHomebridgeMqtt.cpp
+++ b/src/ArduinoHomebridgeMqtt.cpp
@@ -78,12 +78,66 @@ void ArduinoHomebridgeMqtt::addAccessory(const char* name, const char* serviceNa
   publish(topic, payload);
 }
 
+void ArduinoHomebridgeMqtt::addAccessory(const char* name, const char* serviceName, const char* service, const char* characteristics[]) {
+  StaticJsonDocument<1024> chs;
+  for (int i = 0;;i++) {
+    const char* ch = characteristics[i];
+    if (ch) {
+      chs[ch] = "default";
+    } else {
+      break;
+    }
+  }
+  addAccessory(name, serviceName, service, chs.as<JsonObjectConst>());
+}
+
+void ArduinoHomebridgeMqtt::addAccessory(const char* name, const char* serviceName, const char* service, JsonObjectConst characteristics) {
+  StaticJsonDocument<1024> doc;
+  doc["name"] = name;
+  doc["service_name"] = serviceName;
+  doc["service"] = service;
+  for (auto kvp : characteristics) {
+    doc[kvp.key()] = kvp.value();
+  }
+  char payload[1024];
+  serializeJson(doc, payload);
+  const char* topic = "homebridge/to/add";
+  publish(topic, payload);
+}
+
 void ArduinoHomebridgeMqtt::addService(const char* name, const char* serviceName, const char* service) {
   StaticJsonDocument<128> doc;
   doc["name"] = name;
   doc["service_name"] = serviceName;
   doc["service"] = service;
   char payload[128];
+  serializeJson(doc, payload);
+  const char* topic = "homebridge/to/add/service";
+  publish(topic, payload);
+}
+
+void ArduinoHomebridgeMqtt::addService(const char* name, const char* serviceName, const char* service, const char* characteristics[]) {
+  StaticJsonDocument<1024> chs;
+  for (int i = 0;;i++) {
+    const char* ch = characteristics[i];
+    if (ch) {
+      chs[ch] = "default";
+    } else {
+      break;
+    }
+  }
+  addService(name, serviceName, service, chs.as<JsonObjectConst>());
+}
+
+void ArduinoHomebridgeMqtt::addService(const char* name, const char* serviceName, const char* service, JsonObjectConst characteristics) {
+  StaticJsonDocument<1024> doc;
+  doc["name"] = name;
+  doc["service_name"] = serviceName;
+  doc["service"] = service;
+  for (auto kvp : characteristics) {
+    doc[kvp.key()] = kvp.value();
+  }
+  char payload[1024];
   serializeJson(doc, payload);
   const char* topic = "homebridge/to/add/service";
   publish(topic, payload);

--- a/src/ArduinoHomebridgeMqtt.h
+++ b/src/ArduinoHomebridgeMqtt.h
@@ -22,7 +22,11 @@ public:
   void connect(IPAddress server);
   void loop();
   void addAccessory(const char* name, const char* serviceName, const char* service);
+  void addAccessory(const char* name, const char* serviceName, const char* service, const char* characteristics[]);
+  void addAccessory(const char* name, const char* serviceName, const char* service, JsonObjectConst characteristics);
   void addService(const char* name, const char* serviceName, const char* service);
+  void addService(const char* name, const char* serviceName, const char* service, const char* characteristics[]);
+  void addService(const char* name, const char* serviceName, const char* service, JsonObjectConst characteristics);
   void removeAccessory(const char* name);
   void removeService(const char* name, const char* serviceName);
   void getAccessory(const char* name);


### PR DESCRIPTION
This change adds support for adding optional characteristics and changing properties as described in [homebridge-mqtt](https://github.com/cflurin/homebridge-mqtt#define-characterstic).

Two new variants of `addAccessory` and `addService` are added: one taking an array of strings to support adding optional characteristics with default values and one taking a `JsonObject` to support defining custom property values.

The biggest decision here is the size of the `JsonDocument` being created. I kept the stack allocated document to keep with the rest of the design, but maybe a safer bet would be to heap allocate (only in these specific cases) using the largest heap block, but this might introduce portability issues.