### PR TITLE
Support for sending and receiving values other than int

### DIFF
--- a/src/ArduinoHomebridgeMqtt.cpp
+++ b/src/ArduinoHomebridgeMqtt.cpp
@@ -2,7 +2,7 @@
 
 ArduinoHomebridgeMqtt::ArduinoHomebridgeMqtt() {}
 
-void ArduinoHomebridgeMqtt::onSetValueFromHomebridge(std::function<void(const char* name, const char* serviceName, const char* characteristic, int value)> callback) {
+void ArduinoHomebridgeMqtt::onSetValueFromHomebridge(std::function<void(const char* name, const char* serviceName, const char* characteristic, JsonVariantConst value)> callback) {
   this->callback = callback;
   mqttClient.onMessage([this](char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) -> void {
     // Serial.printf("Message arrived [%s] ", topic);
@@ -21,7 +21,7 @@ void ArduinoHomebridgeMqtt::onSetValueFromHomebridge(std::function<void(const ch
         JsonObject characteristics = serviceNameKeyValue.value().as<JsonObject>();
         for (JsonPair characteristicKeyValue: characteristics) {
           const char* characteristic = characteristicKeyValue.key().c_str();
-          const int value = characteristicKeyValue.value().as<int>();
+          JsonVariantConst value = characteristicKeyValue.value().as<JsonVariantConst>();
           this->callback(name, serviceName, characteristic, value);
         }
       }
@@ -31,7 +31,7 @@ void ArduinoHomebridgeMqtt::onSetValueFromHomebridge(std::function<void(const ch
       const char* name = doc["name"];
       const char* serviceName = doc["service_name"];
       const char* characteristic = doc["characteristic"];
-      const int value = doc["value"];
+      JsonVariantConst value = doc["value"];
       this->callback(name, serviceName, characteristic, value);
     }
   });
@@ -118,6 +118,30 @@ void ArduinoHomebridgeMqtt::getAccessory(const char* name) {
 }
 
 void ArduinoHomebridgeMqtt::setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, int value) {
+  StaticJsonDocument<256> doc;
+  doc["name"] = name;
+  doc["service_name"] = serviceName;
+  doc["characteristic"] = characteristic;
+  doc["value"] = value;
+  char payload[256];
+  serializeJson(doc, payload);
+  const char* topic = "homebridge/to/set";
+  publish(topic, payload);
+}
+
+void ArduinoHomebridgeMqtt::setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, float value) {
+  StaticJsonDocument<256> doc;
+  doc["name"] = name;
+  doc["service_name"] = serviceName;
+  doc["characteristic"] = characteristic;
+  doc["value"] = value;
+  char payload[256];
+  serializeJson(doc, payload);
+  const char* topic = "homebridge/to/set";
+  publish(topic, payload);
+}
+
+void ArduinoHomebridgeMqtt::setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, JsonVariantConst value) {
   StaticJsonDocument<256> doc;
   doc["name"] = name;
   doc["service_name"] = serviceName;

--- a/src/ArduinoHomebridgeMqtt.h
+++ b/src/ArduinoHomebridgeMqtt.h
@@ -11,14 +11,14 @@
 class ArduinoHomebridgeMqtt {
 private:
   AsyncMqttClient mqttClient;
-  std::function<void(const char* name, const char* serviceName, const char* characteristic, int value)> callback;
+  std::function<void(const char* name, const char* serviceName, const char* characteristic, JsonVariantConst value)> callback;
   void publish(const char* topic, const char* payload);
   void initMqtt(IPAddress server);
   void connect();
   
 public:
   ArduinoHomebridgeMqtt();
-  void onSetValueFromHomebridge(std::function<void(const char* name, const char* serviceName, const char* characteristic, int value)>);
+  void onSetValueFromHomebridge(std::function<void(const char* name, const char* serviceName, const char* characteristic, JsonVariantConst value)>);
   void connect(IPAddress server);
   void loop();
   void addAccessory(const char* name, const char* serviceName, const char* service);
@@ -27,6 +27,8 @@ public:
   void removeService(const char* name, const char* serviceName);
   void getAccessory(const char* name);
   void setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, int value);
+  void setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, float value);
+  void setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, JsonVariantConst value);
 };
 
 #endif


### PR DESCRIPTION
The library currently only supports sending and receiving integers. Many HomeKit values are integers, but there are a fair numbers of floats too, the most common being the various temperature characteristics. This change adds support for any value type by using leveraging `JsonVariant`.

**This is a breaking change** because the type of the callback function changed. I believe it should be possible to still support the `int` variant with a wrapper callback, but I didn't fully investigate yet.