### PR TITLE
Support for debug logs over mqtt

### DIFF
--- a/src/ArduinoHomebridgeMqtt.h
+++ b/src/ArduinoHomebridgeMqtt.h
@@ -10,6 +10,7 @@
 
 class ArduinoHomebridgeMqtt {
 private:
+  bool debugMode = false;
   AsyncMqttClient mqttClient;
   std::function<void(const char* name, const char* serviceName, const char* characteristic, int value)> callback;
   void publish(const char* topic, const char* payload);
@@ -27,6 +28,9 @@ public:
   void removeService(const char* name, const char* serviceName);
   void getAccessory(const char* name);
   void setValueToHomebridge(const char* name, const char* serviceName, const char* characteristic, int value);
+  void setDebugEnabled(bool enabled);
+  void debug(const char* message);
+  void debugf(const char* format, ...);
 };
 
 #endif


### PR DESCRIPTION
This change is L maybe more controversial than my other two but I found it handy while working on my project: it allows sending debug messages over mqtt and listens to a topic to turn debugging on and off.